### PR TITLE
[ADD] pre-work about Admin model test code

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,5 +1,21 @@
 class Admin < ApplicationRecord
+  include BCrypt
+
   self.primary_key = :email
 
-  alias_attribute :password_digest, :password
+  def password_decryption
+    Password.new(password)
+  end
+
+  def password_encryption=(new_password)
+    self.password = Password.create(new_password)
+  end
+
+  def self.create!(**kwargs)
+    instance = super kwargs
+    instance.password = Password.create(instance.password)
+    instance.save
+
+    instance
+  end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,14 +19,14 @@ default: &default
 
 development:
   <<: *default
-  database: Jindo_development
+  database: entry
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: Jindo_test
+  database: entry
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 0) do
 
   create_table :user, primary_key: :email, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string :password, null: false
-    t.integer :receipt_number, null: false, auto_increment: true
+    t.integer :receipt_number, null: false
     t.string :apply_type
     t.string :additional_type
     t.string :grade_type

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :admin do
-    
+    email { FFaker::Internet.free_email }
+    password { BCrypt::Password.create FFaker::Internet.password }
+    name { FFaker::NameKR.name }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'factory_bot_rails'
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 


### PR DESCRIPTION
# [ADD] pre-work about Admin model test code
## 목적
### 요약
Admin 테이블의 테스트 코드를 짜기 위한 사전 작업을 했습니다.
### 상세
상세 설명
1. db 오류를 피하기 위해 auto increment 옵션 해제 (AI 속성을 가진 컬럼이 PK가 아니면 오류 발생)
2. db연결을 위한 db명 지정
3. spec helper 파일에 테스트 라이브러리 설정을 위한 종속성 부여
4. 비밀번호 암호화를 위한 메서드 작성
5. 테스트 라이브러리 객체 생성 시 속성별 기본값 설정