### PR TITLE
[FIX] routing & database configure

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,6 +1,6 @@
 class School < ApplicationRecord
   self.primary_key = :school_code
 
-  has_many :graduated_applications
-  has_many :ungraduated_applications
+  has_many :graduated_applications, foreign_key: :school_code
+  has_many :ungraduated_applications, foreign_key: :school_code
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,16 +1,16 @@
 class User < ApplicationRecord
   self.primary_key = :email
 
-  enum apply_type: %w[MEISTER SOCIAL_ONE_PARENT SOCIAL_FROM_NORTH
+  enum apply_type: %w[COMMON MEISTER SOCIAL_ONE_PARENT SOCIAL_FROM_NORTH
                       SOCIAL_MULTICULTURAL SOCIAL_BASIC_LIVING
                       SOCIAL_LOWEST_INCOME SOCIAL_TEEN_HOUSEHOLDER]
   enum additional_type: %w[NATIONAL_MERIT PRIVILEGED_ADMISSION NOT_APPLICABLE]
   enum grade_type: %w[GED UNGRADUATED GRADUATED]
   enum sex: %w[MALE FEMALE]
 
-  has_one :ged_application
-  has_one :graduated_application
-  has_one :ungraduated_application
-  has_one :status
-  has_one :calculated_score
+  has_one :ged_application, foreign_key: :user_email
+  has_one :graduated_application, foreign_key: :user_email
+  has_one :ungraduated_application, foreign_key: :user_email
+  has_one :status, foreign_key: :user_email
+  has_one :calculated_score, foreign_key: :user_email
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   resources :statistics, only: :index
 
   get '/applicants', to: 'applicants#show'
-  resources :applicants, only: :index
+  get '/applicants/:index', to: 'applicants#index'
   patch '/applicants', to: 'applicants#update'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,8 @@ Rails.application.routes.draw do
   put '/auth', to: 'authentications#refresh'
 
   resources :statistics, only: :index
-  resources :applicants, only: %i[show index update], param: :email
+
+  get '/applicants', to: 'applicants#show'
+  resources :applicants, only: :index
+  patch '/applicants', to: 'applicants#update'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,19 +35,19 @@ ActiveRecord::Schema.define(version: 0) do
     t.boolean :is_passed_interview
     t.boolean :is_final_submit
     t.datetime :submitted_at
-    t.string :exam_core
+    t.string :exam_code
   end
   change_column :status, :user_email, :string
 
   create_table :user, primary_key: :email, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string :password, null: false
     t.integer :receipt_number, null: false
-    t.string :apply_type
-    t.string :additional_type
-    t.string :grade_type
+    t.integer :apply_type
+    t.integer :additional_type
+    t.integer :grade_type
     t.boolean :is_daejeon
     t.string :name
-    t.string :sex
+    t.integer :sex
     t.date :birth_date
     t.string :parent_name
     t.string :parent_tel
@@ -117,6 +117,4 @@ ActiveRecord::Schema.define(version: 0) do
     t.datetime :modified_at, null: false
   end
   change_column :ungraduated_application, :user_email, :string
-
-
 end

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,3 +1,5 @@
+require_relative 'factory_bot_helpers'
+
 FactoryBot.define do
   factory :admin do
     email { FFaker::Internet.free_email }

--- a/spec/factories/calculated_scores.rb
+++ b/spec/factories/calculated_scores.rb
@@ -1,5 +1,12 @@
+require_relative 'factory_bot_helpers'
+
 FactoryBot.define do
   factory :calculated_score do
-    
+    volunteer_score { 15 }
+    attendance_score { 15 }
+    conversion_score { 150 }
+    final_score { 180 }
+    created_at { Time.zone.now }
+    modified_at { Time.zone.now }
   end
 end

--- a/spec/factories/factory_bot_helpers.rb
+++ b/spec/factories/factory_bot_helpers.rb
@@ -1,0 +1,17 @@
+def cellphone
+  number = FFaker::PhoneNumberKR.mobile_phone_number
+  number[3] = '-'
+  number[8] = '-'
+  number
+end
+
+def telephone
+  number = FFaker::PhoneNumberKR.home_work_phone_number
+  number.each_char.with_index do |value, index|
+    number[index] = '-' if value == ' '
+  end
+end
+
+def rand_boolean
+  [true, false].sample
+end

--- a/spec/factories/ged_applications.rb
+++ b/spec/factories/ged_applications.rb
@@ -1,5 +1,9 @@
+require_relative 'factory_bot_helpers'
+
 FactoryBot.define do
   factory :ged_application do
-    
+    ged_average_score { 600 }
+    created_at { Time.zone.now }
+    modified_at { Time.zone.now }
   end
 end

--- a/spec/factories/graduated_applications.rb
+++ b/spec/factories/graduated_applications.rb
@@ -1,5 +1,22 @@
+require_relative 'factory_bot_helpers'
+
 FactoryBot.define do
   factory :graduated_application do
-    
+    student_number { '30535' }
+    school_tel { telephone }
+    volunteer_time { rand(100) }
+    full_cut_count { 0 }
+    period_cut_count { 0 }
+    late_count { 0 }
+    early_leave_count { 0 }
+    korean { 'A' }
+    social { 'A' }
+    history { 'A' }
+    math { 'A' }
+    science { 'A' }
+    tech_and_home { 'A' }
+    english { 'A' }
+    created_at { Time.zone.now }
+    modified_at { Time.zone.now }
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,5 +1,10 @@
+require_relative 'factory_bot_helpers'
+
 FactoryBot.define do
   factory :school do
-    
+    school_code { rand(10_000..99_999).to_s }
+    school_name { '수완하나중' }
+    school_full_name { '수완하나중학교' }
+    school_address { '광주광역시 광산구 수완로 105번길 47' }
   end
 end

--- a/spec/factories/statuses.rb
+++ b/spec/factories/statuses.rb
@@ -1,5 +1,13 @@
+require_relative 'factory_bot_helpers'
+
 FactoryBot.define do
   factory :status do
-    
+    is_paid { rand_boolean }
+    is_printed_application_arrived { rand_boolean }
+    is_passed_first_apply { rand_boolean }
+    is_passed_interview { rand_boolean }
+    is_final_submit { rand_boolean }
+    submitted_at { Time.zone.now }
+    exam_code { '123456' }
   end
 end

--- a/spec/factories/ungraduated_applications.rb
+++ b/spec/factories/ungraduated_applications.rb
@@ -1,5 +1,22 @@
+require_relative 'factory_bot_helpers'
+
 FactoryBot.define do
   factory :ungraduated_application do
-    
+    student_number { '30535' }
+    school_tel { telephone }
+    volunteer_time { rand(100) }
+    full_cut_count { 0 }
+    period_cut_count { 0 }
+    late_count { 0 }
+    early_leave_count { 0 }
+    korean { 'A' }
+    social { 'A' }
+    history { 'A' }
+    math { 'A' }
+    science { 'A' }
+    tech_and_home { 'A' }
+    english { 'A' }
+    created_at { Time.zone.now }
+    modified_at { Time.zone.now }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,26 @@
+require_relative 'factory_bot_helpers'
+
 FactoryBot.define do
   factory :user do
-    
+    email { FFaker::Internet.free_email }
+    password { FFaker::Internet.password }
+    receipt_number { 1 }
+    apply_type { rand(0..7) }
+    additional_type { rand(0..2) }
+    grade_type { rand(1..2) }
+    is_daejeon { rand_boolean }
+    name { FFaker::NameKR.name }
+    sex { rand(0..1) }
+    birth_date { FFaker::Time.between('2005-01-01 00:00', '2005-12-31 23:59') }
+    parent_name { FFaker::NameKR.name }
+    parent_tel { cellphone }
+    applicant_tel { cellphone }
+    address { FFaker::AddressKR.road_addess }
+    post_code { FFaker::AddressKR.postal_code }
+    user_photo { '/home/ubuntu/image.jpg' }
+    home_tel { telephone }
+    self_introduction { FFaker::Tweet.tweet }
+    study_plan { FFaker::Tweet.body }
+    created_at { Time.zone.now }
   end
 end


### PR DESCRIPTION
# [FIX] fixed configure
## 목적
### 요약
데이터베이스 및 라우팅 설정 변경
### 상세
1. "COMMON" enum 속성 추가 및 "user", "school" 모델에 FK 설정 추가
2. "exam_code" 컬럼 오탈자 수정 및 enum 컬럼들의 자료형 변경 (string -> integer)
3. 기존 resources로 묶여있던 라우팅 쪼갬. (email을 패스파라미터로 받으면 발생하는 이슈 때문에 쿼리 파라미터로 변경함에 따라 라우팅도 변경됨)
4 . 3번 커밋에 의해 두 액션의 라우팅이 겹침에 따라 기존 쿼리 파라미터로 받던 지원자 목록 엔드포인트의 index를 패스 파라미터로 받도록 변경
## 영향을 미치는 부분
applicant API 라우팅 및 데이터베이스 설정