### PR TITLE
[ADD] applicants controller test code

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     receipt_number { 1 }
     apply_type { rand(0..7) }
     additional_type { rand(0..2) }
-    grade_type { rand(1..2) }
+    grade_type { rand(0..2) }
     is_daejeon { rand_boolean }
     name { FFaker::NameKR.name }
     sex { rand(0..1) }

--- a/spec/requests/applicants_request_spec.rb
+++ b/spec/requests/applicants_request_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe 'Applicants', type: :request do
     it '> invalid type of token' do
       request('patch',
               '/applicants',
-              true,
+              { email: @user.email },
               @jwt_base.create_refresh_token(email: @user.email))
 
       expect(response.status).to equal(403)

--- a/spec/requests/applicants_request_spec.rb
+++ b/spec/requests/applicants_request_spec.rb
@@ -1,5 +1,91 @@
 require 'rails_helper'
+require 'jwt_base'
+require_relative 'request_helpers'
 
-RSpec.describe "Applicants", type: :request do
+RSpec.describe 'Applicants', type: :request do
+  before(:all) do
+    set_database
+  end
 
+  describe 'GET#show' do
+    it '> return application information' do
+      request('get', '/applicants', { email: @user.email }, true)
+
+      valid_response = { applicant_information: {
+        status: {
+          is_paid: @user.status.is_paid,
+          is_arrived: @user.status.is_printed_application_arrived,
+          is_final_submit: @user.status.is_final_submit
+        },
+
+        privacy: {
+          user_photo: @user.user_photo,
+          name: @user.name,
+          birth_date: @user.birth_date,
+          grade_type: @user.grade_type,
+          apply_type: @user.apply_type,
+          applicant_tel: @user.applicant_tel,
+          parent_tel: @user.parent_tel,
+          home_tel: @user.home_tel,
+          email: @user.email
+        },
+
+        evaluation: {
+          conversion_score: @user.calculated_score.conversion_score,
+          self_introduction: @user.self_introduction,
+          study_plan: @user.study_plan
+        }
+      } }
+
+      unless @user.grade_type == 'GED'
+        @user = @user.send(@grade_type)
+        privacy = valid_response[:applicant_information][:privacy]
+        evaluation = valid_response[:applicant_information][:evaluation]
+
+        privacy[:school_name] = @user.school.school_full_name
+        privacy[:school_address] = @user.school.school_address
+        privacy[:school_tel] = @user.school_tel
+        evaluation[:volunteer_time] = @user.volunteer_time
+        evaluation[:full_absent_count] = @user.full_cut_count
+        evaluation[:early_leave_count] = @user.early_leave_count
+        evaluation[:late_count] = @user.late_count
+        evaluation[:period_absent_count] = @user.period_cut_count
+
+        valid_response[:applicant_information][:privacy] = privacy
+        valid_response[:applicant_information][:evaluation] = evaluation
+      end
+
+      expect(response.body).to equal(valid_response)
+    end
+
+    it '> invalid params' do
+      request('get', '/applicants', false, true)
+
+      expect(response.status).to equal(400)
+    end
+
+    it '> unauthorized token' do
+      request('get', '/applicants', { email: @user.email }, false)
+
+      expect(response.status).to equal(401)
+    end
+
+    it '> invalid type of token' do
+      request('get',
+              '/applicants',
+              true,
+              @jwt_base.create_refresh_token(email: @user.email))
+
+      expect(response.status).to equal(403)
+    end
+
+    it '> invalid email' do
+      request('get',
+              '/applicants',
+              { email: 'hello_world@korea.korea' },
+              true)
+
+      expect(response.status).to equal(404)
+    end
+  end
 end

--- a/spec/requests/request_helpers.rb
+++ b/spec/requests/request_helpers.rb
@@ -1,0 +1,31 @@
+def request(method, url, params = false, headers = false)
+  parameters = {}
+
+  if params
+    parameters[:params] = params
+  end
+
+  if headers == true
+    parameters[:headers] = { Authorization: "Bearer #{@token}" }
+  elsif params
+    parameters[:headers] = { Authorization: "Bearer #{headers}" }
+  end
+
+  send(method, url, parameters)
+end
+
+def set_database
+  @jwt_base = JWTBase.new(ENV['SECRET_KEY_BASE'], 1.days, 2.weeks)
+  @token = @jwt_base.create_access_token(email: create(:admin).email)
+  @user = create(:user)
+  @grade_type = @user.grade_type.downcase + '_application'
+  create(:status, user_email: @user.email)
+  argument = if @grade_type == 'ged_application'
+               { user_email: @user.email }
+             else
+               { school_code: create(:school).school_code, user_email: @user.email }
+             end
+
+  create(@grade_type.to_s, argument)
+  create(:calculated_score, user_email: @user.email)
+end


### PR DESCRIPTION
# [ADD] applicants controller test code
## 목적
### 요약
지원자의 상태를 보여주는 컨트롤러(이하 applicants 컨트롤러)의 테스트 코드를 작성했습니다.
### 상세
1. applicants 컨트롤러 테스트 코드의 헬퍼 메소드 작성
2. applicants 컨트롤러의 지원자 세부정보 페이지 테스트 코드 작성
3. applicants 컨트롤러의 지원자 목록 색인 페이지 테스트 코드 작성
4. 지원자 목록 세부 페이지의 쿼리 파라미터인 index 값도 테스트 코드에 반영될 수 있도록 변경(밑에 patch 컨트롤러 테스트 코드가 살짝 섞였는데 이것도 커밋 따로 뺄 걸 그랬네요. 죄송합니다.)
5. 테스트 코드 요청값 유효하게 변경
6. 개발 편의를 위해 제한했던 test case를 확대
## 영향을 미치는 부분
applicants 컨트롤러
## 참조(선택)
연관된 이슈 번호들
